### PR TITLE
fixed getHomePageTable() bug 

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -149,7 +149,7 @@ searchInput.addEventListener("keydown", (e) => {
   }
 });
 
-hamburger.addEventListener("click", getHomePageTable());
+hamburger.addEventListener("click", getHomePageTable);
 
 // did we finally get it right progresssssss 
 // git branches take some work to understand like this exercise


### PR DESCRIPTION
-fixed bug where getHomePageTable() was being executed when hamburger event listener was not being called
-this event listener will eventually be discontinued when function properly displays the entire home page table and testing without wasting API requests is no longer needed