### PR TITLE
refactoring the getSearchToken controller function and searchToken()

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ app.use(express.json());
 
 app.use('/api/coin-data/get', coinData);
 // this is where my issue is edit and fix tmw
-app.use('/api/search-coin/get/:dynamic', searchToken);
+app.use('/api/search-coin/get/', searchToken);
 
 app.listen(3000, () => {
   console.log("It's alive HAUHAHUAHUAHUA!!!!")

--- a/controllers/coin-data.js
+++ b/controllers/coin-data.js
@@ -5,7 +5,7 @@ const { response } = require("express");
 const tt_api_coin_by_mc = 'https://openapi.taptools.io/api/v1/token/top/mcap';
 const api_params = '?type=mcap&page=1&perPage=20'
 
-const tt_api_search_coin = 'https://openapi.taptools.io/api/v1/token/mcap/';
+const tt_api_search_coin = 'https://openapi.taptools.io/api/v1/token/mcap';
 let api_input_param = ''
 
 const getCoinData = (request, response) => {
@@ -28,8 +28,9 @@ const getCoinData = (request, response) => {
 
 const getSearchToken = (request, response) => {
     const { unit } = request.query;
-    console.log(unit + " this far huh");
+    console.log(" this far huh " + unit);
     api_input_param = unit;
+    console.log(tt_api_search_coin + api_input_param)
     axios.defaults.headers.common = {
         "X-API-Key": process.env.TAPTOOLS_API_KEY,
     };

--- a/public/index.js
+++ b/public/index.js
@@ -21,7 +21,7 @@ const regex = `/^(?!^0\.00$)(([1-9][\d]{0,6})|([0]))\.[\d]{2}$/`;
 const searchToken = async () => {
   try {
     console.log(searchInput.value);
-    const tokenData = await fetch("/api/search-coin/get/?" + `unit=${searchInput.value}`);
+    const tokenData = await fetch(`/api/search-coin/get/?unit=${searchInput.value}`);
     const data = tokenData.json();
 
     displayTokenData(data);


### PR DESCRIPTION
-took out URL parameters for my searchToken controller and searchToken(), and instead used query strings
-refactored these functions to accept query strings so I could successfully extract the query value into my back-end
